### PR TITLE
regs_module.v: implement TPM_ACCESS register

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,6 @@ git clone https://github.com/Dasharo/verilog-tpm-fifo-registers.git
 iverilog -o tpm_fifo_regs regs_tb.v regs_module.v defines.v
 ```
 
-> It is likely that one can see a few warnings - these are not that important
-> right now and we can just skip them
-
 3. After compilation has ended, we can use `vvp` tool to generate the `.vcd`
    file with timing simulation content:
 
@@ -58,8 +55,14 @@ Testing simple register reads without delay
 Testing simple register reads with delay
 Checking register values against expected.txt
 Checking if RO registers are writable
-Testing TPM_INT_VECTOR write without delay
-Testing TPM_INT_VECTOR write with delay
+Testing mechanisms for changing locality
+Testing mechanisms for seizing locality
+Testing TPM_INT_VECTOR write without delay - proper locality
+Testing TPM_INT_VECTOR write with delay - proper locality
+Testing TPM_INT_VECTOR write without delay - wrong locality
+Testing TPM_INT_VECTOR write with delay - wrong locality
+Testing TPM_INT_VECTOR write without delay - no locality
+Testing TPM_INT_VECTOR write with delay - no locality
 ```
 
 Order, description and number of tests may change in the future. Make sure that
@@ -74,3 +77,7 @@ will be produced.
 ```bash
 gtkwave regs_tb.vcd
 ```
+
+To make it easier to navigate between timing diagrams and testbench code, a
+signal named `test` contains an abbreviation of currently executing test case.
+Add it to the diagram and set its data format to ASCII.

--- a/expected.txt
+++ b/expected.txt
@@ -1,5 +1,5 @@
 // 0x00000000
-81    // TPM_ACCESS (1B) - TODO: locality state machine
+81    // TPM_ACCESS (1B)
 ff
 ff
 ff

--- a/expected.txt
+++ b/expected.txt
@@ -51,7 +51,7 @@ ff
 ff
 // 0x00000030
 00    // TPM_INTERFACE_ID (4B)
-20
+21
 00
 00
 ff

--- a/regs_module.v
+++ b/regs_module.v
@@ -142,7 +142,12 @@ module regs_module (
             if (data_io[1]) begin           // requestUse
               if (activeLocality === `LOCALITY_NONE)
                 activeLocality <= addrLocality;
-              else
+              // Specification is written in a way that suggests that requestUse is actually set in
+              // the following case, but it would be cleared by writing to activeLocality. Blocking
+              // the write here results in different pendingRequest values for other localities, but
+              // it is consistent with existing TPMs. This is a corner case that shouldn't be hit by
+              // a well-written software, but for compatibility do whatever other vendors are doing.
+              else if (activeLocality !== addrLocality)
                 requestUse[addrLocality] <= 1'b1;
             end else if (data_io[3]) begin  // Seize
               // Specification doesn't explicitly say how to handle write to this bit if no locality
@@ -156,7 +161,7 @@ module regs_module (
                 beenSeized[activeLocality]  <= 1'b1;
               end
             end else if (data_io[4]) begin  // beenSeized
-              beenSeized[addrLocality]  <= 1'b1;
+              beenSeized[addrLocality]  <= 1'b0;
             end else if (data_io[5]) begin  // activeLocality
               if (addrLocality === activeLocality) begin
                 casez (requestUse)

--- a/regs_module.v
+++ b/regs_module.v
@@ -105,8 +105,7 @@ module regs_module (
               // FIFO interface as defined in PTP for TPM 2.0
               2'b00:        data <= 8'h00;
               // TIS supported, CRB not supported, Locality 0 only
-              // TODO: change to 8'h21 when all 5 localities are supported
-              2'b01:        data <= 8'h20;
+              2'b01:        data <= 8'h21;
               // We don't support changes between TIS and CRB
               default:      data <= 8'h00;
             endcase

--- a/regs_module.v
+++ b/regs_module.v
@@ -4,6 +4,8 @@
 
 `include "defines.v"
 
+`define LOCALITY_NONE	4'b1111
+
 module regs_module (
     clk_i,
     data_io,
@@ -29,11 +31,12 @@ module regs_module (
   output wire [ 3:0] irq_num;   // IRQ number, copy of TPM_INT_VECTOR_x.sirqVec
   output wire        interrupt; // Whether interrupt should be signaled to host, active high
 
-  // Internal signals and registers
+  // Internal signals
   reg [ 7:0] data = 0;
   reg        driving_data = 0;
   reg        wr_done_reg = 0;
 
+  // Registers and fields same for every locality
   reg [31:0] int_enable = 0;
   reg [ 7:0] int_vector = 0;
   reg [31:0] did_vid = `TwPM;
@@ -47,99 +50,177 @@ module regs_module (
   reg        stsValidIntOccured = 0;
   reg        dataAvailIntOccured = 0;
 
+  // Per-locality fields
+  reg  [3:0] activeLocality = `LOCALITY_NONE;
+  reg  [4:0] requestUse = 5'h00;
+  reg  [4:0] beenSeized = 5'h00;
+
   // verilog_format: on
 
-  always @(posedge clk_i) begin
+  always @(posedge clk_i) begin : main
+    reg [3:0] addrLocality;
+    addrLocality = addr_i[15:12];
     if (data_req && ~data_rd) begin
       // Parse address and prepare proper data
-      casez (addr_i[11:0])
-        // TPM_ACCESS - TODO
-        `TPM_INT_ENABLE: begin
-          case (addr_i[1:0])
-            2'b00:        data <= {commandReadyEnable, 2'b00, /* typePolarity = low level */ 2'b01,
-                                   localityChangeIntEnable, stsValidIntEnable, dataAvailIntEnable};
-            2'b11:        data <= {globalIntEnable, 7'h00};
-            default:      data <= 8'h00;
-          endcase
-        end
-        `TPM_INT_VECTOR:  data <= int_vector;
-        `TPM_INT_STATUS: begin
-          case (addr_i[1:0])
-            2'b00:        data <= {commandReadyIntOccured, 4'b0000, localityChangeIntOccured,
-                                   stsValidIntOccured, dataAvailIntOccured};
-            default:      data <= 8'h00;
-          endcase
-        end
-        `TPM_INTF_CAPABILITY: begin
-          case (addr_i[1:0])
-            // TODO: for now only dataAvail and localityChange interrupts enabled, support the rest
-            2'b00:        data <= 8'h15;
-            // Static burst count, legacy transfer size only
-            2'b01:        data <= 8'h01;
-            2'b10:        data <= 8'h00;
-            // Interface version = 1.3 for TPM 2.0
-            2'b11:        data <= 8'h30;
-          endcase
-        end
-        // TPM_STS - TODO
-        // TPM_DATA_FIFO, TPM_XDATA_FIFO - TODO
-        `TPM_INTERFACE_ID: begin
-          case (addr_i[1:0])
-            // FIFO interface as defined in PTP for TPM 2.0
-            2'b00:        data <= 8'h00;
-            // TIS supported, CRB not supported, Locality 0 only
-            // TODO: change to 8'h21 when all 5 localities are supported
-            2'b01:        data <= 8'h20;
-            // We don't support changes between TIS and CRB
-            default:      data <= 8'h00;
-          endcase
-        end
-        `TPM_DID_VID: begin
-          case (addr_i[1:0])
-            2'b00:        data <= did_vid[ 7: 0];
-            2'b01:        data <= did_vid[15: 8];
-            2'b10:        data <= did_vid[23:16];
-            2'b11:        data <= did_vid[31:24];
-          endcase
-        end
-        `TPM_RID:         data <= 8'h00;
-        default:          data <= 8'hFF;
-      endcase
+      if (addrLocality < 4'h5) begin   // Locality 0-4
+        casez (addr_i[11:0])
+          `TPM_ACCESS: begin
+            data <= {/* tpmRegValidSts */ 1'b1, /* Reserved */ 1'b0,
+                     addrLocality === activeLocality ? 1'b1 : 1'b0,
+                     beenSeized[addrLocality], /* Seize, write only */ 1'b0,
+                     /* pendingRequest */ (requestUse & ~(5'h01 << addrLocality)) !== 5'h00 ? 1'b1 : 1'b0,
+                     requestUse[addrLocality], /* tpmEstablishment, TODO */ 1'b1};
+          end
+          `TPM_INT_ENABLE: begin
+            case (addr_i[1:0])
+              2'b00:        data <= {commandReadyEnable, 2'b00, /* typePolarity = low level */ 2'b01,
+                                     localityChangeIntEnable, stsValidIntEnable, dataAvailIntEnable};
+              2'b11:        data <= {globalIntEnable, 7'h00};
+              default:      data <= 8'h00;
+            endcase
+          end
+          `TPM_INT_VECTOR:  data <= int_vector;
+          `TPM_INT_STATUS: begin
+            case (addr_i[1:0])
+              2'b00:        data <= {commandReadyIntOccured, 4'b0000, localityChangeIntOccured,
+                                     stsValidIntOccured, dataAvailIntOccured};
+              default:      data <= 8'h00;
+            endcase
+          end
+          `TPM_INTF_CAPABILITY: begin
+            case (addr_i[1:0])
+              // TODO: for now only dataAvail and localityChange interrupts enabled, support the rest
+              2'b00:        data <= 8'h15;
+              // Static burst count, legacy transfer size only
+              2'b01:        data <= 8'h01;
+              2'b10:        data <= 8'h00;
+              // Interface version = 1.3 for TPM 2.0
+              2'b11:        data <= 8'h30;
+            endcase
+          end
+          // TPM_STS - TODO
+          // TPM_DATA_FIFO, TPM_XDATA_FIFO - TODO
+          `TPM_INTERFACE_ID: begin
+            case (addr_i[1:0])
+              // FIFO interface as defined in PTP for TPM 2.0
+              2'b00:        data <= 8'h00;
+              // TIS supported, CRB not supported, Locality 0 only
+              // TODO: change to 8'h21 when all 5 localities are supported
+              2'b01:        data <= 8'h20;
+              // We don't support changes between TIS and CRB
+              default:      data <= 8'h00;
+            endcase
+          end
+          `TPM_DID_VID: begin
+            case (addr_i[1:0])
+              2'b00:        data <= did_vid[ 7: 0];
+              2'b01:        data <= did_vid[15: 8];
+              2'b10:        data <= did_vid[23:16];
+              2'b11:        data <= did_vid[31:24];
+            endcase
+          end
+          `TPM_RID:         data <= 8'h00;
+          default:          data <= 8'hFF;
+        endcase
+      end else begin    // Locality > 4
+        data <= 8'hFF;
+      end
       driving_data  <= 1;
     end else if (data_rd && ~data_req) begin
       // Stop driving data
       driving_data  <= 0;
     end else if (data_wr && ~wr_done) begin
-      casez (addr_i[11:0])
-        // TPM_ACCESS - TODO
-        `TPM_INT_ENABLE: begin
-          case (addr_i[1:0])
-            2'b00: begin
-              dataAvailIntEnable      <= data_io[0];
-              stsValidIntEnable       <= data_io[1];
-              localityChangeIntEnable <= data_io[2];
-              commandReadyEnable      <= data_io[7];
+      if (addrLocality < 4'h5) begin   // Locality 0-4
+        casez (addr_i[11:0])
+          `TPM_ACCESS: begin
+            // PC Client PTP for TPM 2.0, 6.5.2.4:
+            // > Any write operation to the TPM_ACCESS_x register with more than one field set to
+            // > a 1 MAY be treated as vendor specific.
+            // This implementation acts on least significant set bit. This way a given write tries
+            // to request the use of locality peacefully before seizing it. Read-only bits are
+            // ignored, even when set.
+            if (data_io[1]) begin           // requestUse
+              if (activeLocality === `LOCALITY_NONE)
+                activeLocality <= addrLocality;
+              else
+                requestUse[addrLocality] <= 1'b1;
+            end else if (data_io[3]) begin  // Seize
+              // Specification doesn't explicitly say how to handle write to this bit if no locality
+              // is set. From informative comment it can be conjectured that such case has lower
+              // priority than Locality 0. As such, this case immediately sets active locality.
+              if (activeLocality === `LOCALITY_NONE)
+                activeLocality <= addrLocality;
+              else if (addrLocality > activeLocality) begin
+                activeLocality              <= addrLocality;
+                requestUse[addrLocality]    <= 1'b0;
+                beenSeized[activeLocality]  <= 1'b1;
+              end
+            end else if (data_io[4]) begin  // beenSeized
+              beenSeized[addrLocality]  <= 1'b1;
+            end else if (data_io[5]) begin  // activeLocality
+              if (addrLocality === activeLocality) begin
+                casez (requestUse)
+                  5'b1????: begin
+                    activeLocality  <= 4'h4;
+                    requestUse[4]   <= 1'b0;
+                  end
+                  5'b01???: begin
+                    activeLocality  <= 4'h3;
+                    requestUse[3]   <= 1'b0;
+                  end
+                  5'b001??: begin
+                    activeLocality  <= 4'h2;
+                    requestUse[2]   <= 1'b0;
+                  end
+                  5'b0001?: begin
+                    activeLocality  <= 4'h1;
+                    requestUse[1]   <= 1'b0;
+                  end
+                  5'b00001: begin
+                    activeLocality  <= 4'h0;
+                    requestUse[0]   <= 1'b0;
+                  end
+                  5'b00000: activeLocality <= `LOCALITY_NONE;
+                endcase
+              end else if (requestUse[addrLocality])
+                requestUse[addrLocality]  <= 1'b0;
             end
-            2'b11: globalIntEnable    <= data_io[7];
-          endcase
-        end
-        `TPM_INT_VECTOR:  int_vector[3:0] <= data_io[3:0];
-        `TPM_INT_STATUS: begin
-          case (addr_i[1:0])
-            2'b00: begin
-              if (data_io[0]) dataAvailIntOccured       <= 0;
-              if (data_io[1]) stsValidIntOccured        <= 0;
-              if (data_io[2]) localityChangeIntOccured  <= 0;
-              if (data_io[7]) commandReadyIntOccured    <= 0;
+          end
+          `TPM_INT_ENABLE: begin
+            if (addrLocality === activeLocality) begin
+              case (addr_i[1:0])
+                2'b00: begin
+                  dataAvailIntEnable      <= data_io[0];
+                  stsValidIntEnable       <= data_io[1];
+                  localityChangeIntEnable <= data_io[2];
+                  commandReadyEnable      <= data_io[7];
+                end
+                2'b11: globalIntEnable    <= data_io[7];
+              endcase
             end
-          endcase
-        end
-        // TPM_INTF_CAPABILITY - read-only register
-        // TPM_STS - TODO
-        // TPM_DATA_FIFO, TPM_XDATA_FIFO - TODO
-        // TPM_INTERFACE_ID - writable bits are for switching between CRB and TIS, not supported
-        // TPM_DID_VID, TPM_RID - read-only registers
-      endcase
+          end
+          `TPM_INT_VECTOR: begin
+            if (addrLocality === activeLocality) int_vector[3:0] <= data_io[3:0];
+          end
+          `TPM_INT_STATUS: begin
+            if (addrLocality === activeLocality) begin
+              case (addr_i[1:0])
+                2'b00: begin
+                  if (data_io[0]) dataAvailIntOccured       <= 0;
+                  if (data_io[1]) stsValidIntOccured        <= 0;
+                  if (data_io[2]) localityChangeIntOccured  <= 0;
+                  if (data_io[7]) commandReadyIntOccured    <= 0;
+                end
+              endcase
+            end
+          end
+          // TPM_INTF_CAPABILITY - read-only register
+          // TPM_STS - TODO
+          // TPM_DATA_FIFO, TPM_XDATA_FIFO - TODO
+          // TPM_INTERFACE_ID - writable bits are for switching between CRB and TIS, not supported
+          // TPM_DID_VID, TPM_RID - read-only registers
+        endcase
+      end
       wr_done_reg <= 1;
     end else if (wr_done && ~data_wr) begin
       wr_done_reg <= 0;

--- a/regs_tb.v
+++ b/regs_tb.v
@@ -26,6 +26,7 @@ module regs_tb ();
   reg  [ 7:0] data_reg;
   reg  [31:0] tmp_reg;
   reg  [ 7:0] expected [0:4095];
+  reg [127:0] test = "begin"; // For easier navigation in gtkwave
 
   // verilog_format: on
 
@@ -74,12 +75,16 @@ module regs_tb ();
     for (i = 0; i < 4; i++) read_b (addr + i, data[8*i +: 8]);
   endtask
 
+  function [15:0] locality_addr (input integer locality, input [15:0] addr);
+    locality_addr = addr + 16'h1000 * locality;
+  endfunction
+
   task request_locality (input integer locality);
-    write_b (`TPM_ACCESS + 16'h1000 * locality, 8'h02);
+    write_b (locality_addr (locality, `TPM_ACCESS), 8'h02);
   endtask
 
   task relinquish_locality (input integer locality);
-    write_b (`TPM_ACCESS + 16'h1000 * locality, 8'h20);
+    write_b (locality_addr (locality, `TPM_ACCESS), 8'h20);
   endtask
 
   initial begin
@@ -103,6 +108,9 @@ module regs_tb ();
 
     $readmemh("expected.txt", expected);
 
+    //////////////////////////////////////////////////////
+    test = "read w/o delay";
+
     $display("Testing simple register reads without delay");
     read_w (`TPM_DID_VID & `MASK_4B, tmp_reg);
     if (tmp_reg !== `TwPM)
@@ -115,7 +123,22 @@ module regs_tb ();
     read_b (`TPM_RID + 1, tmp_reg[7:0]);
     if (tmp_reg[7:0] !== 8'hFF)
       $display("### Unexpected value of reserved register (0x%h) @ %t", tmp_reg[7:0], $realtime);
-    // TODO: repeat above tests for other localities
+
+    // For different locality this set of registers should return the same values
+    read_w (locality_addr (2, `TPM_DID_VID & `MASK_4B), tmp_reg);
+    if (tmp_reg !== `TwPM)
+      $display("### Unexpected DID_VID value (0x%h) @ %t", tmp_reg, $realtime);
+
+    read_b (locality_addr (2, `TPM_RID), tmp_reg[7:0]);
+    if (tmp_reg[7:0] !== 8'h00)
+      $display("### Unexpected RID value (0x%h) @ %t", tmp_reg[7:0], $realtime);
+
+    read_b (locality_addr (2, `TPM_RID + 1), tmp_reg[7:0]);
+    if (tmp_reg[7:0] !== 8'hFF)
+      $display("### Unexpected value of reserved register (0x%h) @ %t", tmp_reg[7:0], $realtime);
+
+    //////////////////////////////////////////////////////
+    test = "read with delay";
 
     $display("Testing simple register reads with delay");
     delay = 10;
@@ -130,7 +153,22 @@ module regs_tb ();
     read_b (`TPM_RID + 1, tmp_reg[7:0]);
     if (tmp_reg[7:0] !== 8'hFF)
       $display("### Unexpected value of reserved register (0x%h) @ %t", tmp_reg[7:0], $realtime);
-    // TODO: repeat above tests for other localities
+
+    // For different locality this set of registers should return the same values
+    read_w (locality_addr (1, `TPM_DID_VID & `MASK_4B), tmp_reg);
+    if (tmp_reg !== `TwPM)
+      $display("### Unexpected DID_VID value (0x%h) @ %t", tmp_reg, $realtime);
+
+    read_b (locality_addr (1, `TPM_RID), tmp_reg[7:0]);
+    if (tmp_reg[7:0] !== 8'h00)
+      $display("### Unexpected RID value (0x%h) @ %t", tmp_reg[7:0], $realtime);
+
+    read_b (locality_addr (1, `TPM_RID + 1), tmp_reg[7:0]);
+    if (tmp_reg[7:0] !== 8'hFF)
+      $display("### Unexpected value of reserved register (0x%h) @ %t", tmp_reg[7:0], $realtime);
+
+    //////////////////////////////////////////////////////
+    test = "expected values";
 
     delay = 0;
 
@@ -141,7 +179,15 @@ module regs_tb ();
         $display("### Wrong value at 0x%0h (got 0x%h, expected 0x%h)", i[15:0], tmp_reg[7:0],
                  expected[i]);
     end
-    // TODO: repeat above test for other localities
+
+    for (i = 0; i < 4096; i++) begin
+      read_b (locality_addr (1, i), tmp_reg[7:0]);
+      if (tmp_reg[7:0] !== expected[i])
+        $display("### Wrong value at 0x%0h (got 0x%h, expected 0x%h)", i[15:0], tmp_reg[7:0],
+                 expected[i]);
+    end
+
+    test = "ro is ro";
 
     $display("Checking if RO registers are writable");
     // Except for TPM_(X)DATA_FIFO and TPM_HASH_* writes of 0 should be safe
@@ -156,7 +202,265 @@ module regs_tb ();
                    expected[i]);
       end
     end
-    // TODO: repeat above test for other localities
+
+    for (i = 0; i < 4096; i++) begin
+      // No break/continue until SystemVerilog...
+      if (((i & `MASK_4B) !== (`TPM_DATA_FIFO & `MASK_4B)) &&
+          ((i & `MASK_4B) !== (`TPM_XDATA_FIFO & `MASK_4B))) begin
+        write_b (locality_addr (1, i), 8'h00);
+        read_b (locality_addr (1, i), tmp_reg[7:0]);
+        if (tmp_reg[7:0] !== expected[i])
+          $display("### Wrong value at 0x%0h (got 0x%h, expected 0x%h)", i[15:0], tmp_reg[7:0],
+                   expected[i]);
+      end
+    end
+
+    //////////////////////////////////////////////////////
+    test = "change locality";
+
+    $display("Testing mechanisms for changing locality");
+    for (i = 0; i < 5; i++) begin
+      read_b (locality_addr (i, `TPM_ACCESS), tmp_reg[7:0]);
+      if (tmp_reg[7:0] !== 8'h81)
+        $display("### Wrong TPM_ACCESS value (%h) for Locality %d @ %t", tmp_reg[7:0], i[2:0],
+                 $realtime);
+    end
+
+    request_locality (0);
+
+    for (i = 0; i < 5; i++) begin : f1
+      reg [7:0] exp;
+      case (i)
+        0:        exp = 8'hA1;
+        default:  exp = 8'h81;
+      endcase
+      read_b (locality_addr (i, `TPM_ACCESS), tmp_reg[7:0]);
+      if (tmp_reg[7:0] !== exp)
+        $display("### Wrong TPM_ACCESS value (%h) for Locality %d @ %t", tmp_reg[7:0], i[2:0],
+                 $realtime);
+    end
+
+    // NOTE: this doesn't follow specification. According to the specification, if requestUse is 0,
+    // it can be set to 1 regardless of activeLocality. It should be cleared when current locality
+    // relinquishes control. Until then, pendingRequest for other localities probably should be set.
+    // The implementation does a shortcut here and ignores a write to requestUse if activeLocality
+    // is already set. This is consistent with how other TPMs approach this.
+    request_locality (0);
+
+    for (i = 0; i < 5; i++) begin : f2
+      reg [7:0] exp;
+      case (i)
+        0:        exp = 8'hA1;
+        default:  exp = 8'h81;
+      endcase
+      read_b (locality_addr (i, `TPM_ACCESS), tmp_reg[7:0]);
+      if (tmp_reg[7:0] !== exp)
+        $display("### Wrong TPM_ACCESS value (%h) for Locality %d @ %t", tmp_reg[7:0], i[2:0],
+                 $realtime);
+    end
+
+    request_locality (1);
+
+    for (i = 0; i < 5; i++) begin : f3
+      reg [7:0] exp;
+      case (i)
+        0:        exp = 8'hA5;
+        1:        exp = 8'h83;
+        default:  exp = 8'h85;
+      endcase
+      read_b (locality_addr (i, `TPM_ACCESS), tmp_reg[7:0]);
+      if (tmp_reg[7:0] !== exp)
+        $display("### Wrong TPM_ACCESS value (%h) for Locality %d @ %t", tmp_reg[7:0], i[2:0],
+                 $realtime);
+    end
+
+    request_locality (2);
+
+    for (i = 0; i < 5; i++) begin : f4
+      reg [7:0] exp;
+      case (i)
+        0:        exp = 8'hA5;
+        1, 2:     exp = 8'h87;
+        default:  exp = 8'h85;
+      endcase
+      read_b (locality_addr (i, `TPM_ACCESS), tmp_reg[7:0]);
+      if (tmp_reg[7:0] !== exp)
+        $display("### Wrong TPM_ACCESS value (%h) for Locality %d @ %t", tmp_reg[7:0], i[2:0],
+                 $realtime);
+    end
+
+    relinquish_locality (1);
+
+    for (i = 0; i < 5; i++) begin : f5
+      reg [7:0] exp;
+      case (i)
+        0:        exp = 8'hA5;
+        2:        exp = 8'h83;
+        default:  exp = 8'h85;
+      endcase
+      read_b (locality_addr (i, `TPM_ACCESS), tmp_reg[7:0]);
+      if (tmp_reg[7:0] !== exp)
+        $display("### Wrong TPM_ACCESS value (%h) for Locality %d @ %t", tmp_reg[7:0], i[2:0],
+                 $realtime);
+    end
+
+    relinquish_locality (0);
+
+    for (i = 0; i < 5; i++) begin : f6
+      reg [7:0] exp;
+      case (i)
+        2:        exp = 8'hA1;
+        default:  exp = 8'h81;
+      endcase
+      read_b (locality_addr (i, `TPM_ACCESS), tmp_reg[7:0]);
+      if (tmp_reg[7:0] !== exp)
+        $display("### Wrong TPM_ACCESS value (%h) for Locality %d @ %t", tmp_reg[7:0], i[2:0],
+                 $realtime);
+    end
+
+    request_locality (0);
+    request_locality (1);
+    relinquish_locality (2);
+
+    for (i = 0; i < 5; i++) begin : f7
+      reg [7:0] exp;
+      case (i)
+        0:        exp = 8'h83;
+        1:        exp = 8'hA5;
+        default:  exp = 8'h85;
+      endcase
+      read_b (locality_addr (i, `TPM_ACCESS), tmp_reg[7:0]);
+      if (tmp_reg[7:0] !== exp)
+        $display("### Wrong TPM_ACCESS value (%h) for Locality %d @ %t", tmp_reg[7:0], i[2:0],
+                 $realtime);
+    end
+
+    relinquish_locality (0);
+
+    for (i = 0; i < 5; i++) begin : f8
+      reg [7:0] exp;
+      case (i)
+        1:        exp = 8'hA1;
+        default:  exp = 8'h81;
+      endcase
+      read_b (locality_addr (i, `TPM_ACCESS), tmp_reg[7:0]);
+      if (tmp_reg[7:0] !== exp)
+        $display("### Wrong TPM_ACCESS value (%h) for Locality %d @ %t", tmp_reg[7:0], i[2:0],
+                 $realtime);
+    end
+
+    //////////////////////////////////////////////////////
+    test = "seize locality";
+
+    // TODO: add tests for other effects of seizing (TPM_STS, FIFO etc.)
+    $display("Testing mechanisms for seizing locality");
+    write_b (locality_addr (2, `TPM_ACCESS), 8'h08);
+
+    for (i = 0; i < 5; i++) begin : f9
+      reg [7:0] exp;
+      case (i)
+        1:        exp = 8'h91;
+        2:        exp = 8'hA1;
+        default:  exp = 8'h81;
+      endcase
+      read_b (locality_addr (i, `TPM_ACCESS), tmp_reg[7:0]);
+      if (tmp_reg[7:0] !== exp)
+        $display("### Wrong TPM_ACCESS value (%h) for Locality %d @ %t", tmp_reg[7:0], i[2:0],
+                 $realtime);
+    end
+
+    write_b (locality_addr (0, `TPM_ACCESS), 8'h08);
+
+    for (i = 0; i < 5; i++) begin : f10
+      reg [7:0] exp;
+      case (i)
+        1:        exp = 8'h91;
+        2:        exp = 8'hA1;
+        default:  exp = 8'h81;
+      endcase
+      read_b (locality_addr (i, `TPM_ACCESS), tmp_reg[7:0]);
+      if (tmp_reg[7:0] !== exp)
+        $display("### Wrong TPM_ACCESS value (%h) for Locality %d @ %t", tmp_reg[7:0], i[2:0],
+                 $realtime);
+    end
+
+    relinquish_locality (2);
+    write_b (locality_addr (0, `TPM_ACCESS), 8'h08);
+
+    for (i = 0; i < 5; i++) begin : f11
+      reg [7:0] exp;
+      case (i)
+        0:        exp = 8'hA1;
+        1:        exp = 8'h91;
+        default:  exp = 8'h81;
+      endcase
+      read_b (locality_addr (i, `TPM_ACCESS), tmp_reg[7:0]);
+      if (tmp_reg[7:0] !== exp)
+        $display("### Wrong TPM_ACCESS value (%h) for Locality %d @ %t", tmp_reg[7:0], i[2:0],
+                 $realtime);
+    end
+
+    write_b (locality_addr (1, `TPM_ACCESS), 8'h10);
+
+    for (i = 0; i < 5; i++) begin : f12
+      reg [7:0] exp;
+      case (i)
+        0:        exp = 8'hA1;
+        default:  exp = 8'h81;
+      endcase
+      read_b (locality_addr (i, `TPM_ACCESS), tmp_reg[7:0]);
+      if (tmp_reg[7:0] !== exp)
+        $display("### Wrong TPM_ACCESS value (%h) for Locality %d @ %t", tmp_reg[7:0], i[2:0],
+                 $realtime);
+    end
+
+    write_b (locality_addr (1, `TPM_ACCESS), 8'h08);
+
+    for (i = 0; i < 5; i++) begin : f13
+      reg [7:0] exp;
+      case (i)
+        0:        exp = 8'h91;
+        1:        exp = 8'hA1;
+        default:  exp = 8'h81;
+      endcase
+      read_b (locality_addr (i, `TPM_ACCESS), tmp_reg[7:0]);
+      if (tmp_reg[7:0] !== exp)
+        $display("### Wrong TPM_ACCESS value (%h) for Locality %d @ %t", tmp_reg[7:0], i[2:0],
+                 $realtime);
+    end
+
+    write_b (locality_addr (2, `TPM_ACCESS), 8'h08);
+
+    for (i = 0; i < 5; i++) begin : f14
+      reg [7:0] exp;
+      case (i)
+        0, 1:     exp = 8'h91;
+        2:        exp = 8'hA1;
+        default:  exp = 8'h81;
+      endcase
+      read_b (locality_addr (i, `TPM_ACCESS), tmp_reg[7:0]);
+      if (tmp_reg[7:0] !== exp)
+        $display("### Wrong TPM_ACCESS value (%h) for Locality %d @ %t", tmp_reg[7:0], i[2:0],
+                 $realtime);
+    end
+
+    write_b (locality_addr (0, `TPM_ACCESS), 8'h10);
+    write_b (locality_addr (1, `TPM_ACCESS), 8'h10);
+    relinquish_locality (2);
+
+    for (i = 0; i < 5; i++) begin : f15
+      reg [7:0] exp;
+      case (i)
+        default:  exp = 8'h81;
+      endcase
+      read_b (locality_addr (i, `TPM_ACCESS), tmp_reg[7:0]);
+      if (tmp_reg[7:0] !== exp)
+        $display("### Wrong TPM_ACCESS value (%h) for Locality %d @ %t", tmp_reg[7:0], i[2:0],
+                 $realtime);
+    end
+
+    //////////////////////////////////////////////////////
+    test = "int prp loc -dly";
 
     request_locality (0);
 
@@ -178,6 +482,8 @@ module regs_tb ();
     if (tmp_reg[7:0] !== 8'h0A)
       $display("### Reserved bits in TPM_INT_VECTOR modified @ %t", IRQn, $realtime);
 
+    test = "int prp loc +dly";
+
     $display("Testing TPM_INT_VECTOR write with delay - proper locality");
     delay = 10;
     write_b (`TPM_INT_VECTOR, 8'h05);
@@ -196,47 +502,53 @@ module regs_tb ();
     if (tmp_reg[7:0] !== 8'h0A)
       $display("### Reserved bits in TPM_INT_VECTOR modified @ %t", IRQn, $realtime);
 
+    //////////////////////////////////////////////////////
+    test = "int bad loc -dly";
+
     write_b (`TPM_INT_VECTOR, 8'h00);
-    relinquish_locality (0);
-    request_locality (2);
 
     $display("Testing TPM_INT_VECTOR write without delay - wrong locality");
     delay = 0;
-    write_b (`TPM_INT_VECTOR, 8'h05);
+    write_b (locality_addr (3, `TPM_INT_VECTOR), 8'h05);
     if (IRQn !== 4'h0)
       $display("### Wrong IRQn reported (0x%h) @ %t", IRQn, $realtime);
 
-    read_b (`TPM_INT_VECTOR, tmp_reg[7:0]);
+    read_b (locality_addr (3, `TPM_INT_VECTOR), tmp_reg[7:0]);
     if (tmp_reg[7:0] !== 8'h00)
       $display("### Wrong IRQn read back (0x%h) @ %t", IRQn, $realtime);
 
-    write_b (`TPM_INT_VECTOR, 8'hFA);
+    write_b (locality_addr (3, `TPM_INT_VECTOR), 8'hFA);
     if (IRQn !== 4'h0)
       $display("### Wrong IRQn reported (0x%h) @ %t", IRQn, $realtime);
 
-    read_b (`TPM_INT_VECTOR, tmp_reg[7:0]);
+    read_b (locality_addr (3, `TPM_INT_VECTOR), tmp_reg[7:0]);
     if (tmp_reg[7:0] !== 8'h00)
       $display("### Reserved bits in TPM_INT_VECTOR modified @ %t", IRQn, $realtime);
+
+    test = "int bad loc +dly";
 
     $display("Testing TPM_INT_VECTOR write with delay - wrong locality");
     delay = 10;
-    write_b (`TPM_INT_VECTOR, 8'h05);
+    write_b (locality_addr (3, `TPM_INT_VECTOR), 8'h05);
     if (IRQn !== 4'h0)
       $display("### Wrong IRQn reported (0x%h) @ %t", IRQn, $realtime);
 
-    read_b (`TPM_INT_VECTOR, tmp_reg[7:0]);
+    read_b (locality_addr (3, `TPM_INT_VECTOR), tmp_reg[7:0]);
     if (tmp_reg[7:0] !== 8'h00)
       $display("### Wrong IRQn read back (0x%h) @ %t", IRQn, $realtime);
 
-    write_b (`TPM_INT_VECTOR, 8'hFA);
+    write_b (locality_addr (3, `TPM_INT_VECTOR), 8'hFA);
     if (IRQn !== 4'h0)
       $display("### Wrong IRQn reported (0x%h) @ %t", IRQn, $realtime);
 
-    read_b (`TPM_INT_VECTOR, tmp_reg[7:0]);
+    read_b (locality_addr (3, `TPM_INT_VECTOR), tmp_reg[7:0]);
     if (tmp_reg[7:0] !== 8'h00)
       $display("### Reserved bits in TPM_INT_VECTOR modified @ %t", IRQn, $realtime);
 
-    relinquish_locality (2);
+    //////////////////////////////////////////////////////
+    test = "int no loc -dly";
+
+    relinquish_locality (0);
 
     $display("Testing TPM_INT_VECTOR write without delay - no locality");
     delay = 0;
@@ -256,6 +568,8 @@ module regs_tb ();
     if (tmp_reg[7:0] !== 8'h00)
       $display("### Reserved bits in TPM_INT_VECTOR modified @ %t", IRQn, $realtime);
 
+    test = "int no loc +dly";
+
     $display("Testing TPM_INT_VECTOR write with delay - no locality");
     delay = 10;
     write_b (`TPM_INT_VECTOR, 8'h05);
@@ -273,6 +587,10 @@ module regs_tb ();
     read_b (`TPM_INT_VECTOR, tmp_reg[7:0]);
     if (tmp_reg[7:0] !== 8'h00)
       $display("### Reserved bits in TPM_INT_VECTOR modified @ %t", IRQn, $realtime);
+
+    //////////////////////////////////////////////////////
+
+    test = "end";
 
     #3000;
     $stop;

--- a/regs_tb.v
+++ b/regs_tb.v
@@ -187,7 +187,7 @@ module regs_tb ();
     end
 
     for (i = 0; i < 4096; i++) begin
-      read_b (locality_addr (1, i), tmp_reg[7:0]);
+      read_b (locality_addr (4, i), tmp_reg[7:0]);
       if (tmp_reg[7:0] !== expected[i])
         $display("### Wrong value at 0x%0h (got 0x%h, expected 0x%h)", i[15:0], tmp_reg[7:0],
                  expected[i]);
@@ -213,8 +213,8 @@ module regs_tb ();
       // No break/continue until SystemVerilog...
       if (((i & `MASK_4B) !== (`TPM_DATA_FIFO & `MASK_4B)) &&
           ((i & `MASK_4B) !== (`TPM_XDATA_FIFO & `MASK_4B))) begin
-        write_b (locality_addr (1, i), 8'h00);
-        read_b (locality_addr (1, i), tmp_reg[7:0]);
+        write_b (locality_addr (4, i), 8'h00);
+        read_b (locality_addr (4, i), tmp_reg[7:0]);
         if (tmp_reg[7:0] !== expected[i])
           $display("### Wrong value at 0x%0h (got 0x%h, expected 0x%h)", i[15:0], tmp_reg[7:0],
                    expected[i]);


### PR DESCRIPTION
Specification leaves some parts of the implementation to be defined by vendors. Assumptions made by this commit:

- Unset locality has lower priority than Locality 0.
- TPM_INT_* registers can be read from all localities (including no locality), but can be written just from active locality. There is one set of those registers aliased between all localities.
- Implementation makes it possible to set requestUse from Locality 4, wait for lower priority locality to relinquish control of the TPM and then have activeLocality set for Locality 4. Access to Locality 4 register space should be blocked by platform, so described case should be impossible to do in practice.