### PR TITLE
regs_module.v: simplify RAM interface

### DIFF
--- a/defines.v
+++ b/defines.v
@@ -33,4 +33,7 @@
 
 `define TwPM                32'h4D507754        // "TwPM" in little endian
 
+`define OP_TYPE_NONE        4'h0
+`define OP_TYPE_CMD         4'h1
+
 // verilog_format: on

--- a/regs_module.svg
+++ b/regs_module.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="645" height="350" viewBox="-108 -20 645.0 350.0" version="1.1">
+width="638" height="330" viewBox="-108 -20 638.0 330.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -68,22 +68,22 @@ width="645" height="350" viewBox="-108 -20 645.0 350.0" version="1.1">
 <g transform="translate(280,37)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
 <text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">wr_done</text>
-<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">wire</text>
+<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg</text>
 </g>
 <g transform="translate(280,57)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
 <text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">data_rd</text>
-<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">wire</text>
+<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg</text>
 </g>
 <g transform="translate(280,77)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="3"/>
 <text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">irq_num</text>
-<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">wire <tspan fill="#039BE5">[3:0]</tspan></text>
+<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg <tspan fill="#039BE5">[3:0]</tspan></text>
 </g>
 <g transform="translate(280,97)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
 <text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">interrupt</text>
-<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">wire</text>
+<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg</text>
 </g>
 </g>
 <g transform="translate(0,165.0)">
@@ -97,16 +97,16 @@ width="645" height="350" viewBox="-108 -20 645.0 350.0" version="1.1">
 <g transform="translate(280,17)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
 <text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">exec</text>
-<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">wire</text>
+<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg</text>
 </g>
 <g transform="translate(280,37)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
 <text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">abort</text>
-<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">wire</text>
+<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg</text>
 </g>
 </g>
 <g transform="translate(0,232.0)">
-<rect x="0" y="-15.0" width="280" height="107.0" stroke="#000000" fill="#FFAFFD" stroke-width="1"/>
+<rect x="0" y="-15.0" width="280" height="87.0" stroke="#000000" fill="#FFAFFD" stroke-width="1"/>
 <text class="fnt2" x="140.0" y="0" text-anchor="middle" dy="2.5">RAM interface</text>
 <g transform="translate(0,17)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="3"/>
@@ -116,7 +116,7 @@ width="645" height="350" viewBox="-108 -20 645.0 350.0" version="1.1">
 <g transform="translate(280,17)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="3"/>
 <text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">RAM_addr</text>
-<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">wire <tspan fill="#039BE5">[RAM_ADDR_WIDTH-1:0]</tspan></text>
+<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg <tspan fill="#039BE5">[RAM_ADDR_WIDTH-1:0]</tspan></text>
 </g>
 <g transform="translate(280,37)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="3"/>
@@ -125,14 +125,9 @@ width="645" height="350" viewBox="-108 -20 645.0 350.0" version="1.1">
 </g>
 <g transform="translate(280,57)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
-<text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">RAM_rd</text>
-<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">wire</text>
-</g>
-<g transform="translate(280,77)">
-<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
 <text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">RAM_wr</text>
-<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">wire</text>
+<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg</text>
 </g>
 </g>
-<rect x="1.0" y="24.0" width="278.0" height="299.0" stroke="#000000" fill="none" stroke-width="3"/>
+<rect x="1.0" y="24.0" width="278.0" height="279.0" stroke="#000000" fill="none" stroke-width="3"/>
 </svg>

--- a/regs_module.svg
+++ b/regs_module.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
 xmlns:xlink="http://www.w3.org/1999/xlink"
 xml:space="preserve"
-width="638" height="330" viewBox="-108 -20 638.0 330.0" version="1.1">
+width="678" height="390" viewBox="-108 -20 678.0 390.0" version="1.1">
 <style type="text/css">
 <![CDATA[
 .fnt1 {fill:#000000;
@@ -25,16 +25,16 @@ width="638" height="330" viewBox="-108 -20 638.0 330.0" version="1.1">
 </marker>
 </defs>
 <rect x="-108" y="-20" width="100%" height="100%" fill="white"/><g transform="translate(0,0)">
-<rect x="0" y="-15.0" width="280" height="30.0" stroke="#646464" fill="#C8C8C8" stroke-width="1"/>
+<rect x="0" y="-15.0" width="320" height="30.0" stroke="#646464" fill="#C8C8C8" stroke-width="1"/>
 <g transform="translate(0,0)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
 <text class="fnt1" x="10" y="0" text-anchor="normal" dy="3.5">RAM_ADDR_WIDTH</text>
 </g>
 </g>
-<rect x="1.0" y="-14.0" width="278.0" height="28.0" stroke="#646464" fill="none" stroke-width="3"/>
+<rect x="1.0" y="-14.0" width="318.0" height="28.0" stroke="#646464" fill="none" stroke-width="3"/>
 <g transform="translate(0,38.0)">
-<rect x="0" y="-15.0" width="280" height="127.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
-<text class="fnt2" x="140.0" y="0" text-anchor="middle" dy="2.5">LPC/SPI module interface</text>
+<rect x="0" y="-15.0" width="320" height="127.0" stroke="#000000" fill="#C5DBFC" stroke-width="1"/>
+<text class="fnt2" x="160.0" y="0" text-anchor="middle" dy="2.5">LPC/SPI module interface</text>
 <g transform="translate(0,17)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1" marker-end="url(#clock)"/>
 <text class="fnt1" x="10" y="0" text-anchor="normal" dy="3.5">clk_i</text>
@@ -60,74 +60,89 @@ width="638" height="330" viewBox="-108 -20 638.0 330.0" version="1.1">
 <text class="fnt1" x="10" y="0" text-anchor="normal" dy="3.5">data_req</text>
 <text class="fnt1" x="-30" y="0" text-anchor="end" dy="3.5" style="fill:#969696">wire</text>
 </g>
-<g transform="translate(280,17)">
+<g transform="translate(320,17)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="3"/>
 <text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">data_o</text>
 <text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg <tspan fill="#039BE5">[7:0]</tspan></text>
 </g>
-<g transform="translate(280,37)">
+<g transform="translate(320,37)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
 <text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">wr_done</text>
 <text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg</text>
 </g>
-<g transform="translate(280,57)">
+<g transform="translate(320,57)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
 <text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">data_rd</text>
 <text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg</text>
 </g>
-<g transform="translate(280,77)">
+<g transform="translate(320,77)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="3"/>
 <text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">irq_num</text>
 <text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg <tspan fill="#039BE5">[3:0]</tspan></text>
 </g>
-<g transform="translate(280,97)">
+<g transform="translate(320,97)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
 <text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">interrupt</text>
 <text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg</text>
 </g>
 </g>
 <g transform="translate(0,165.0)">
-<rect x="0" y="-15.0" width="280" height="67.0" stroke="#000000" fill="#E7FDBA" stroke-width="1"/>
-<text class="fnt2" x="140.0" y="0" text-anchor="middle" dy="2.5">MCU interrupts interface</text>
+<rect x="0" y="-15.0" width="320" height="127.0" stroke="#000000" fill="#E7FDBA" stroke-width="1"/>
+<text class="fnt2" x="160.0" y="0" text-anchor="middle" dy="2.5">MCU data and interrupts interface</text>
 <g transform="translate(0,17)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
 <text class="fnt1" x="10" y="0" text-anchor="normal" dy="3.5">complete</text>
 <text class="fnt1" x="-30" y="0" text-anchor="end" dy="3.5" style="fill:#969696">wire</text>
 </g>
-<g transform="translate(280,17)">
+<g transform="translate(320,17)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">op_type</text>
+<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg <tspan fill="#039BE5">[3:0]</tspan></text>
+</g>
+<g transform="translate(320,37)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">locality</text>
+<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg <tspan fill="#039BE5">[3:0]</tspan></text>
+</g>
+<g transform="translate(320,57)">
+<line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="3"/>
+<text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">buf_len</text>
+<text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg <tspan fill="#039BE5">[RAM_ADDR_WIDTH-1:0]</tspan></text>
+</g>
+<g transform="translate(320,77)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
 <text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">exec</text>
 <text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg</text>
 </g>
-<g transform="translate(280,37)">
+<g transform="translate(320,97)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
 <text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">abort</text>
 <text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg</text>
 </g>
 </g>
-<g transform="translate(0,232.0)">
-<rect x="0" y="-15.0" width="280" height="87.0" stroke="#000000" fill="#FFAFFD" stroke-width="1"/>
-<text class="fnt2" x="140.0" y="0" text-anchor="middle" dy="2.5">RAM interface</text>
+<g transform="translate(0,292.0)">
+<rect x="0" y="-15.0" width="320" height="87.0" stroke="#000000" fill="#FFAFFD" stroke-width="1"/>
+<text class="fnt2" x="160.0" y="0" text-anchor="middle" dy="2.5">RAM interface</text>
 <g transform="translate(0,17)">
 <line x1="-20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="3"/>
 <text class="fnt1" x="10" y="0" text-anchor="normal" dy="3.5">RAM_data_rd</text>
 <text class="fnt1" x="-30" y="0" text-anchor="end" dy="3.5" style="fill:#969696">wire <tspan fill="#039BE5">[7:0]</tspan></text>
 </g>
-<g transform="translate(280,17)">
+<g transform="translate(320,17)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="3"/>
 <text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">RAM_addr</text>
 <text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg <tspan fill="#039BE5">[RAM_ADDR_WIDTH-1:0]</tspan></text>
 </g>
-<g transform="translate(280,37)">
+<g transform="translate(320,37)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="3"/>
 <text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">RAM_data_wr</text>
 <text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg <tspan fill="#039BE5">[7:0]</tspan></text>
 </g>
-<g transform="translate(280,57)">
+<g transform="translate(320,57)">
 <line x1="20" y1="0" x2="0" y2="0" stroke="#000000" fill="none" stroke-width="1"/>
 <text class="fnt1" x="-10" y="0" text-anchor="end" dy="3.5">RAM_wr</text>
 <text class="fnt1" x="30" y="0" text-anchor="normal" dy="3.5" style="fill:#969696">reg</text>
 </g>
 </g>
-<rect x="1.0" y="24.0" width="278.0" height="279.0" stroke="#000000" fill="none" stroke-width="3"/>
+<rect x="1.0" y="24.0" width="318.0" height="339.0" stroke="#000000" fill="none" stroke-width="3"/>
 </svg>

--- a/regs_module.v
+++ b/regs_module.v
@@ -50,7 +50,6 @@ module regs_module
     RAM_addr,
     RAM_data_rd,
     RAM_data_wr,
-    RAM_rd,
     RAM_wr
 );
   // verilog_format: off  // verible-verilog-format messes up comments alignment
@@ -60,11 +59,11 @@ module regs_module
   output reg  [ 7:0] data_o;    // Data to be sent (I/O Read) to host
   input  wire [15:0] addr_i;    // 16-bit LPC Peripheral Address
   input  wire        data_wr;   // Signal to data provider that data_i has valid write data
-  output             wr_done;   // Signal from data provider that data_i has been read
-  output             data_rd;   // Signal from data provider that data_o has data for read
+  output reg         wr_done;   // Signal from data provider that data_i has been read
+  output reg         data_rd;   // Signal from data provider that data_o has data for read
   input  wire        data_req;  // Signal to data provider that is requested (@posedge) or
                                 // has been read (@negedge)
-  output      [ 3:0] irq_num;   // IRQ number, copy of TPM_INT_VECTOR_x.sirqVec
+  output reg  [ 3:0] irq_num;   // IRQ number, copy of TPM_INT_VECTOR_x.sirqVec
   output reg         interrupt; // Whether interrupt should be signaled to host, active high
   //# {{MCU interrupts interface}}
   output reg         exec;      // Signal that RAM has command that should be executed
@@ -74,12 +73,11 @@ module regs_module
   output reg  [RAM_ADDR_WIDTH-1:0] RAM_addr;  // Command/response address space size, default 2KiB
   input  wire [ 7:0] RAM_data_rd; // 1 byte of data from RAM
   output reg  [ 7:0] RAM_data_wr; // 1 byte of data to RAM
-  output wire        RAM_rd;    // Signal to memory to do a read
   output reg         RAM_wr;    // Signal to memory to do a write
 
-  reg         data_rd = 0;
-  reg  [ 3:0] irq_num = 0;
-  reg         wr_done = 0;
+  initial     data_rd = 0;
+  initial     irq_num = 4'h0;
+  initial     wr_done = 0;
 
   // Internal signals
   reg [ 4:0] state = `ST_IDLE;
@@ -478,7 +476,5 @@ module regs_module
     interrupt <= globalIntEnable & |irq_num &
                  (dataAvailIntOccured | stsValidIntOccured | localityChangeIntOccured |
                   commandReadyIntOccured);
-
-  assign RAM_rd = ~RAM_wr;
 
 endmodule

--- a/regs_tb.v
+++ b/regs_tb.v
@@ -30,7 +30,6 @@ module regs_tb ();
   wire [10:0] RAM_addr;       // 2KiB address space, TODO: make it configurable
   reg  [ 7:0] RAM_data_rd;    // 1 byte of data from RAM
   wire [ 7:0] RAM_data_wr;    // 1 byte of data to RAM
-  wire        RAM_rd;         // Signal to memory to do a read
   wire        RAM_wr;         // Signal to memory to do a write
 
   parameter   max_cmd_rsp_size = 2048;
@@ -1054,7 +1053,7 @@ module regs_tb ();
   always @(negedge clk_i) begin
     if (RAM_wr)
       RAM[RAM_addr%max_cmd_rsp_size] <= RAM_data_wr;
-    else if (RAM_rd)
+    else
       RAM_data_rd   <= RAM[RAM_addr%max_cmd_rsp_size];
   end
 
@@ -1079,7 +1078,6 @@ module regs_tb ();
       .RAM_addr(RAM_addr),
       .RAM_data_wr(RAM_data_wr),
       .RAM_data_rd(RAM_data_rd),
-      .RAM_rd(RAM_rd),
       .RAM_wr(RAM_wr)
   );
 


### PR DESCRIPTION
Remove unnecessary signal from code and testbench, make cosmetic changes to produce more readable diagram and recreate it.