### PR TITLE
regs_module.v: add missing initial value for RAM_addr

### DIFF
--- a/regs_module.v
+++ b/regs_module.v
@@ -84,6 +84,7 @@ module regs_module
   initial     data_rd = 0;
   initial     irq_num = 4'h0;
   initial     wr_done = 0;
+  initial     RAM_addr = ~0;
 
   // Internal signals
   reg [ 4:0] state = `ST_IDLE;


### PR DESCRIPTION
Testbench always resets before this value is used, so it wasn't noticed earlier.